### PR TITLE
updated for name change in .json resource file

### DIFF
--- a/src/ResourceManager/EventHub/Commands.EventHub.Test/ScenarioTests/Common.ps1
+++ b/src/ResourceManager/EventHub/Commands.EventHub.Test/ScenarioTests/Common.ps1
@@ -116,8 +116,22 @@ function Get-SecondaryLocation
 
 <#
 .SYNOPSIS
-Cleans the website
+update the New Name in resource file
 #>
+function update-NameInResourceFile ($fileName, $newName )
+{
+ 
+ $fpath = '.\.\Resources\'
+$fileContent = Get-Content $fpath$fileName -raw | ConvertFrom-Json
+
+$fileContent.Name = $newName
+$fileContent.update 
+$fileContent | ConvertTo-Json  | set-content $fpath$fileName
+
+}
+
+
+
 function Clean-Website($resourceGroup, $websiteName)
 {
     if ([Microsoft.Azure.Test.HttpRecorder.HttpMockServer]::Mode -ne [Microsoft.Azure.Test.HttpRecorder.HttpRecorderMode]::Playback) 
@@ -125,6 +139,9 @@ function Clean-Website($resourceGroup, $websiteName)
 		$result = Remove-AzureRmWebsite -ResourceGroupName $resourceGroup.ToString() -WebsiteName $websiteName.ToString() -Force
     }
 }
+
+
+
 
 function PingWebApp($webApp)
 {

--- a/src/ResourceManager/EventHub/Commands.EventHub.Test/ScenarioTests/Common.ps1
+++ b/src/ResourceManager/EventHub/Commands.EventHub.Test/ScenarioTests/Common.ps1
@@ -12,32 +12,6 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------------
 
-<#
-.SYNOPSIS
-Gets a website name for testing.
-#>
-function Get-WebsiteName
-{
-    return getAssetName
-}
-
-<#
-.SYNOPSIS
-Gets a website name for testing.
-#>
-function Get-TrafficManagerProfileName
-{
-    return getAssetName
-}
-
-<#
-.SYNOPSIS
-Gets a website name for testing.
-#>
-function Get-WebHostPlanName
-{
-    return getAssetName 
-}
 
 <#
 .SYNOPSIS
@@ -48,23 +22,6 @@ function Get-ResourceGroupName
     return getAssetName
 }
 
-<#
-.SYNOPSIS
-Gets a backup name for testing.
-#>
-function Get-BackupName
-{
-    return getAssetName
-}
-
-<#
-.SYNOPSIS
-Gets an aseName for testing.
-#>
-function Get-AseName
-{
-    return getAssetName
-}
 
 <#
 .SYNOPSIS
@@ -128,53 +85,4 @@ $fileContent.Name = $newName
 $fileContent.update 
 $fileContent | ConvertTo-Json  | set-content $fpath$fileName
 
-}
-
-
-
-function Clean-Website($resourceGroup, $websiteName)
-{
-    if ([Microsoft.Azure.Test.HttpRecorder.HttpMockServer]::Mode -ne [Microsoft.Azure.Test.HttpRecorder.HttpRecorderMode]::Playback) 
-	{
-		$result = Remove-AzureRmWebsite -ResourceGroupName $resourceGroup.ToString() -WebsiteName $websiteName.ToString() -Force
-    }
-}
-
-
-
-
-function PingWebApp($webApp)
-{
-	if ([Microsoft.Azure.Test.HttpRecorder.HttpMockServer]::Mode -ne [Microsoft.Azure.Test.HttpRecorder.HttpRecorderMode]::Playback) 
-	{
-		try 
-		{
-			$result = Invoke-WebRequest $webApp.HostNames[0] 
-			$statusCode = $result.StatusCode
-		} 
-		catch [System.Net.WebException ] 
-		{ 
-			$statusCode = $_.Exception.Response.StatusCode
-		}
-
-		return $statusCode
-    }
-}
-
-# Create a SAS Uri
-function Get-SasUri
-{
-    param ([string] $storageAccount, [string] $storageKey, [string] $container, [TimeSpan] $duration, [Microsoft.WindowsAzure.Storage.Blob.SharedAccessBlobPermissions] $type)
-
-	$uri = "https://$storageAccount.blob.core.windows.net/$container"
-
-	$destUri = New-Object -TypeName System.Uri($uri);
-	$cred = New-Object -TypeName Microsoft.WindowsAzure.Storage.Auth.StorageCredentials($storageAccount, $storageKey);
-	$destBlob = New-Object -TypeName Microsoft.WindowsAzure.Storage.Blob.CloudPageBlob($destUri, $cred);
-	$policy = New-Object Microsoft.WindowsAzure.Storage.Blob.SharedAccessBlobPolicy;
-	$policy.Permissions = $type;
-	$policy.SharedAccessExpiryTime = (Get-Date).Add($duration);
-	$uri += $destBlob.GetSharedAccessSignature($policy);
-
-	return $uri;
 }

--- a/src/ResourceManager/EventHub/Commands.EventHub.Test/ScenarioTests/ConsumerGroupsTests.ps1
+++ b/src/ResourceManager/EventHub/Commands.EventHub.Test/ScenarioTests/ConsumerGroupsTests.ps1
@@ -18,7 +18,7 @@ Get valid resource group name
 #>
 function Get-ResourceGroupName
 {
-    return "RGName-" + (getAssetName)	
+    return "RGName-" + (getAssetName)
 }
 
 <#
@@ -53,17 +53,25 @@ function Get-NamespaceName
 Tests EventHub Namespace Create List Remove operations.
 #>
 function ConsumerGroupsTests
-{ # Setup    
+{ # Setup
+
+
     $location = Get-Location
 	$resourceGroupName = Get-ResourceGroupName
 	$namespaceName = Get-NamespaceName
 	$eventHubName = Get-EventHubName
-	$consumerGroupName = "consumergroup1"
+	$consumerGroupName = Get-ConsumerGroupName
+
+	update-NameInResourceFile "NewEventHub.json" $eventHubName
+	update-NameInResourceFile "NewConsumerGroup.json" $eventHubName
+
+
     
     Write-Debug "  Create resource group"    
     Write-Debug " Resource Group Name : $resourceGroupName"
     $Result11 = New-AzureRmResourceGroup -Name $resourceGroupName -Location $location -Force
     
+	Write-Debug $Result11
 	Write-Debug "  Create new Evnethub namespace"
     Write-Debug " Namespace name : $namespaceName"
     $result = New-AzureRmEventHubNamespace -ResourceGroup $resourceGroupName -NamespaceName $namespaceName -Location $location

--- a/src/ResourceManager/EventHub/Commands.EventHub.Test/ScenarioTests/EventHubsNamespaceTests.ps1
+++ b/src/ResourceManager/EventHub/Commands.EventHub.Test/ScenarioTests/EventHubsNamespaceTests.ps1
@@ -19,7 +19,6 @@ Get ResourceGroup name
 function Get-ResourceGroupName
 {
     return "RGName-" + (getAssetName)
-	
 }
 
 <#
@@ -42,6 +41,17 @@ function Get-NamespaceName
 
 <#
 .SYNOPSIS
+Get valid AuthorizationRule name
+#>
+function Get-AuthorizationRuleName
+{
+    return "Eventhub-Namespace-AuthorizationRule" + (getAssetName)
+	
+}
+
+
+<#
+.SYNOPSIS
 Tests EventHub Namespace Create List Remove operations.
 #>
 function EventHubsNamespaceTests 
@@ -59,6 +69,9 @@ function EventHubsNamespaceTests
     Write-Debug "NamespaceName : $namespaceName" 
     $result = New-AzureRmEventHubNamespace -ResourceGroup $resourceGroupName -NamespaceName $namespaceName -Location $location -SkuName "Standard" -SkuCapacity "1" -CreateACSNamespace $FALSE
     Wait-Seconds 15
+	
+	# Assert 
+	Assert-True {$result.ProvisioningState -eq "Succeeded"}
 
     Write-Debug "Get the created namespace within the resource group"
     $createdNamespace = Get-AzureRmEventHubNamespace -ResourceGroup $resourceGroupName -NamespaceName $namespaceName
@@ -145,7 +158,10 @@ function EventHubsNamespaceAuthTests
     $location = Get-Location
 	$resourceGroupName = Get-ResourceGroupName
 	$namespaceName = Get-NamespaceName
-	$authRuleName = "TestAuthRule"
+	$authRuleName = Get-AuthorizationRuleName
+	update-NameInResourceFile "NewAuthorizationRule.json" $authRuleName
+	update-NameInResourceFile "SetAuthorizationRule.json" $authRuleName
+	
     
     Write-Debug " Create resource group"    
     Write-Debug "ResourceGroup name : $resourceGroupName"

--- a/src/ResourceManager/EventHub/Commands.EventHub.Test/ScenarioTests/EventHubsTests.ps1
+++ b/src/ResourceManager/EventHub/Commands.EventHub.Test/ScenarioTests/EventHubsTests.ps1
@@ -18,7 +18,7 @@ Get valid resource group name
 #>
 function Get-ResourceGroupName
 {
-    return "RGName-" + (getAssetName)	
+    return "RGName-" + (getAssetName)		
 }
 
 <#
@@ -42,6 +42,17 @@ function Get-NamespaceName
 
 <#
 .SYNOPSIS
+Get valid AuthorizationRule name
+#>
+function Get-AuthorizationRuleName
+{
+    return "Eventhub-Namespace-AuthorizationRule" + (getAssetName)
+	
+}
+
+
+<#
+.SYNOPSIS
 Tests EventHubs Create List Remove operations.
 #>
 function EventHubsTests
@@ -51,6 +62,8 @@ function EventHubsTests
     $resourceGroupName = Get-ResourceGroupName
 	$namespaceName = Get-NamespaceName
 	$eventHubName = Get-EventHubName
+
+	update-NameInResourceFile "NewEventHub.json" $eventHubName	
 
 	# Create Resource Group
     Write-Debug "Create resource group"    
@@ -65,7 +78,7 @@ function EventHubsTests
     Wait-Seconds 15
 
 	# Assert
-	Assert-True {$result.Name -eq $namespaceName}
+	Assert-True {$result.ProvisioningState -eq "Succeeded"}
 	
 
 	# get the created Eventhub Namespace 
@@ -105,15 +118,11 @@ function EventHubsTests
     Write-Debug " Get all the created EventHub "
     $createdEventHubList = Get-AzureRmEventHub -ResourceGroup $resourceGroupName -NamespaceName $namespaceName
 
+	# Assert
     $found = 0
     for ($i = 0; $i -lt $createdEventHubList.Count; $i++)
     {
-        if ($createdEventHubList[$i].Name -eq $eventHubName)
-        {
-            $found = $found + 1
-        }
-
-        if ($createdEventHubList[$i].Name -eq $eventHubName2)
+        if ($createdEventHubList[$i].Name -eq $createdEventHub)
         {
             $found = $found + 1
         }
@@ -157,7 +166,10 @@ function EventHubsAuthTests
 	$resourceGroupName = Get-ResourceGroupName
 	$namespaceName = Get-NamespaceName    
 	$eventHubName = Get-EventHubName	
-    $authRuleName = "TestAuthRule"
+    $authRuleName = Get-AuthorizationRuleName
+	update-NameInResourceFile "NewEventHub.json" $eventHubName	
+	update-NameInResourceFile "NewAuthorizationRule.json" $authRuleName	
+
 
 	# Create ResourceGroup
     Write-Debug " Create resource group"    
@@ -171,7 +183,7 @@ function EventHubsAuthTests
     Wait-Seconds 15
     
 	# Assert
-	Assert-True {$result.Name -eq $namespaceName}
+	Assert-True {$result.ProvisioningState -eq "Succeeded"}
 
 	# Get Created NameSpace
     Write-Debug " Get the created namespace within the resource group"


### PR DESCRIPTION
## Comments

---

This checklist is used to make sure that common issues in a pull request are covered by the creator. You can find a more complete discussion of PowerShell cmdlet best practices [here](https://msdn.microsoft.com/en-us/library/dd878270%28v=vs.85%29.aspx).

Below in **Overall Changes**, check off the boxes that apply to your PR. For the categories that you did not check off, you can remove them from this body. Within each of the categories that you did select, make sure that you can check off **all** of the boxes. 

For information on cleaning up the commits in your pull request, click [here](../documentation/cleaning-up-commits.md).
## Overall Changes
- [ ] [**MANDATORY** - General changes](#general)
- [ ] [**MANDATORY** - Add/remove/edit test(s)](#tests)
- [ ] [Add/remove/edit cmdlet(s)](#cmdlet-signature)
- [ ] [Add/remove/edit parameter(s)](#parameters)
- [ ] [Edit pipeline parameters](#parameters-and-the-pipeline)
### General
- [ ] Title of the PR is clear and informative
- [ ] There are a small number of commits that each have an informative message
- [ ] If it applies, references the bug/issue that the PR fixes
- [ ] All files have the Microsoft copyright header
- [ ] Cmdlets refer to management libraries through nuget references - no dlls are checked in
- [ ] The PR does not introduce breaking changes (unless a major version change occurs in the assembly and module)
### Tests
- [ ] PR includes test coverage for the included changes
- [ ] Tests must use xunit, and should either use Moq to mock management client calls, or use the scenario test framework
- [ ] PowerShell scripts used in tests must not use hard-coded values for location
- [ ] PowerShell scripts used in tests should do any necessary setup as part of the test or suite setup, and should not use hard-coded values for existing resources
- [ ] Tests should not use App.config files for settings
- [ ] Tests should use the built-in PowerShell functions for generating random names when unique names are necessary - this will store names in the test recording
- [ ] Tests should use Start-Sleep to pause rather than Thread.Sleep
### Cmdlet Signature
- [ ] Cmdlet name uses an approved PowerShell verb - use the enums for `VerbsCommon`, `VerbsCommunication`, `VerbsLifecycle`, `VerbsOther` whenever possible
- [ ] Cmdlet noun name uses the AzureRm prefix for management cmdlets, and the Azure prefix for data plane cmdlets
- [ ] Cmdlet specifies the `OutputType` attribute if any output is produced; if the cmdlet produces no output, it should implement a `PassThrough` parameter
- [ ] If the cmdlet makes changes or has side effects, it should implement `ShouldProcess` and have `SupportShouldProcess = true` specified in the cmdlet attribute. See a discussion about correct `ShouldProcess` implementation [here](https://gist.github.com/markcowl/338e16fe5c8bbf195aff9f8af0db585d#what-is-the-change)
- [ ] Cmdlets should derive from AzureRmCmdlet for management cmdlets, and AzureDataCmdlet for data cmdlets
- [ ] If multiple parameter sets are implemented, the cmdlet should specify a `DefaultParameterSetName` in its cmdlet attribute
### Parameters
- [ ] Cmdlets should have no more than four positional parameters
- [ ] Cmdlet parameter sets should be mutually exclusive - each parameter set must have at least one mandatory parameter not in other parameter sets
- [ ] Parameter types should not expose types from the management library - complex parameter types should be defined in the module
- [ ] Complex parameter types are discouraged - a parameter type should be simple types as often as possible. If complex types are used, they should be shallow and easily creatable from a constructor or another cmdlet
- [ ] Parameters should be explicitly marked as Mandatory or not, and should contain a HelpMessage
- [ ] No parameter is of type `object`.
  - Management cmdlets should have the following parameters and aliases:
    - ResourceGroupName with (optional) alias to `ResourceGroup` type string marked as [ValueFromPipelineByPropertyName]
    - Name with alias to `ResourceName` type string marked as [ValueFromPipelineByPropertyName]
    - Location (if appropriate) type string
    - Tag, type `HashTable`
### Parameters and the Pipeline
- [ ] Complex parameters should take values from the pipeline when possible, and certainly when they match the output type of another cmdlet
- [ ] Only one parameter should use ValueFromPipeline per parameter set; parameters from different parameter sets may have this attribute, but should not be convertible
- [ ] No parameter is of type `object`
- [ ] Each management cmdlet should have a parameter set that takes `ResourceGroupName` and `Name` from the pipeline by property value
- [ ] For a given resource type, it should be possible to pipe the output of `Get` and `New` cmdlets to the input of `Set`, `Update`, `Remove` and other action cmdlets for that resource
